### PR TITLE
Prepare for release v0.3.0-rc.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	kmodules.xyz/client-go v0.29.6
 	kmodules.xyz/offshoot-api v0.29.0
-	kubestash.dev/apimachinery v0.4.0-rc.0
+	kubestash.dev/apimachinery v0.4.0-rc.1
 	sigs.k8s.io/controller-runtime v0.16.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -737,8 +737,8 @@ kmodules.xyz/offshoot-api v0.29.0 h1:GHLhxxT9jU1N8+FvOCCeJNyU5g0duYS46UGrs6AHNLY
 kmodules.xyz/offshoot-api v0.29.0/go.mod h1:5NxhBblXoDHWStx9HCDJR2KFTwYjEZ7i1Id3jelIunw=
 kmodules.xyz/prober v0.29.0 h1:Ex7m4F9rH7uWNNJlLgP63ROOM+nUATJkC2L5OQ7nwMg=
 kmodules.xyz/prober v0.29.0/go.mod h1:UtK+HKyI1lFLEKX+HFLyOCVju6TO93zv3kwGpzqmKOo=
-kubestash.dev/apimachinery v0.4.0-rc.0 h1:iElRLTX8WsN4xl49y07Dz1ZD14FCJZp5RZhXwsutNmw=
-kubestash.dev/apimachinery v0.4.0-rc.0/go.mod h1:mqOML23d9Hm2kSyzlRy6Gr69RGEUaOCTWYl2egklac8=
+kubestash.dev/apimachinery v0.4.0-rc.1 h1:lgYW5JdcsPchBm/YYVtAQAflaju/afzdF9tT/B9Cb6Q=
+kubestash.dev/apimachinery v0.4.0-rc.1/go.mod h1:mqOML23d9Hm2kSyzlRy6Gr69RGEUaOCTWYl2egklac8=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=

--- a/vendor/kubestash.dev/apimachinery/apis/storage/v1alpha1/snapshot_types.go
+++ b/vendor/kubestash.dev/apimachinery/apis/storage/v1alpha1/snapshot_types.go
@@ -43,7 +43,6 @@ const (
 // +kubebuilder:printcolumn:name="Snapshot-Time",type="string",JSONPath=".status.snapshotTime"
 // +kubebuilder:printcolumn:name="Deletion-Policy",type="string",JSONPath=".spec.deletionPolicy"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
-// +kubebuilder:printcolumn:name="Verification-Status",type="string",JSONPath=".status.verificationStatus"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Snapshot represents the state of a backup run to a particular Repository.

--- a/vendor/kubestash.dev/apimachinery/crds/storage.kubestash.com_snapshots.yaml
+++ b/vendor/kubestash.dev/apimachinery/crds/storage.kubestash.com_snapshots.yaml
@@ -33,9 +33,6 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .status.verificationStatus
-      name: Verification-Status
-      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -822,7 +822,7 @@ kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.29.0
 ## explicit; go 1.21.5
 kmodules.xyz/prober/api/v1
-# kubestash.dev/apimachinery v0.4.0-rc.0
+# kubestash.dev/apimachinery v0.4.0-rc.1
 ## explicit; go 1.21.5
 kubestash.dev/apimachinery/apis
 kubestash.dev/apimachinery/apis/addons/v1alpha1


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2024.1.26-rc.1
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/7
Signed-off-by: 1gtm <1gtm@appscode.com>