### PR TITLE
Prepare for release v0.3.0-rc.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	kmodules.xyz/client-go v0.29.6
 	kmodules.xyz/offshoot-api v0.29.0
-	kubestash.dev/apimachinery v0.4.0-rc.1.0.20240128101716-91fea71b1878
+	kubestash.dev/apimachinery v0.4.0-rc.2
 	sigs.k8s.io/controller-runtime v0.17.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,8 @@ kmodules.xyz/offshoot-api v0.29.0 h1:GHLhxxT9jU1N8+FvOCCeJNyU5g0duYS46UGrs6AHNLY
 kmodules.xyz/offshoot-api v0.29.0/go.mod h1:5NxhBblXoDHWStx9HCDJR2KFTwYjEZ7i1Id3jelIunw=
 kmodules.xyz/prober v0.29.0 h1:Ex7m4F9rH7uWNNJlLgP63ROOM+nUATJkC2L5OQ7nwMg=
 kmodules.xyz/prober v0.29.0/go.mod h1:UtK+HKyI1lFLEKX+HFLyOCVju6TO93zv3kwGpzqmKOo=
-kubestash.dev/apimachinery v0.4.0-rc.1.0.20240128101716-91fea71b1878 h1:Vo58U38k9io0cL7g11opABPSYI5kkIeUu6fKrffr3rE=
-kubestash.dev/apimachinery v0.4.0-rc.1.0.20240128101716-91fea71b1878/go.mod h1:ysktK/jLtv5SnFgyxmBZmSFDZmD03lFwEF/8bG/VoF8=
+kubestash.dev/apimachinery v0.4.0-rc.2 h1:BSThxK1vQ0wp4JtO5HCVLvEqTP0TJuTqmEmeQOyK738=
+kubestash.dev/apimachinery v0.4.0-rc.2/go.mod h1:ysktK/jLtv5SnFgyxmBZmSFDZmD03lFwEF/8bG/VoF8=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -823,7 +823,7 @@ kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.29.0
 ## explicit; go 1.21.5
 kmodules.xyz/prober/api/v1
-# kubestash.dev/apimachinery v0.4.0-rc.1.0.20240128101716-91fea71b1878
+# kubestash.dev/apimachinery v0.4.0-rc.2
 ## explicit; go 1.21.5
 kubestash.dev/apimachinery/apis
 kubestash.dev/apimachinery/apis/addons/v1alpha1


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2024.1.28-rc.2
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/8
Signed-off-by: 1gtm <1gtm@appscode.com>