### PR TITLE
Prepare for release v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	kmodules.xyz/client-go v0.30.1
 	kmodules.xyz/offshoot-api v0.29.4
-	kubestash.dev/apimachinery v0.8.1-0.20240604180741-126c359043bc
+	kubestash.dev/apimachinery v0.9.0
 	sigs.k8s.io/controller-runtime v0.18.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -646,8 +646,8 @@ kmodules.xyz/offshoot-api v0.29.4 h1:WQV2BIUIoVKKiqZNmZ4gAy367jEdwBhEl3dFCLZM1qA
 kmodules.xyz/offshoot-api v0.29.4/go.mod h1:e+NQ0s4gW/YTPWBWEfdISZcmk+tlTq8IjvP5SLdqvko=
 kmodules.xyz/prober v0.29.0 h1:Ex7m4F9rH7uWNNJlLgP63ROOM+nUATJkC2L5OQ7nwMg=
 kmodules.xyz/prober v0.29.0/go.mod h1:UtK+HKyI1lFLEKX+HFLyOCVju6TO93zv3kwGpzqmKOo=
-kubestash.dev/apimachinery v0.8.1-0.20240604180741-126c359043bc h1:8pJBdyfg+srWoAKpchKo7AzZpUf+Zs8N5idQlNUyIvI=
-kubestash.dev/apimachinery v0.8.1-0.20240604180741-126c359043bc/go.mod h1:ElttP7EeECmi8+qsJJ9s7WjUlKG8MkjHSVo/gV6FV88=
+kubestash.dev/apimachinery v0.9.0 h1:jj5JW6HuhaQogztEhFzVJ7rkDuOaHivX836tPJ1N51E=
+kubestash.dev/apimachinery v0.9.0/go.mod h1:ElttP7EeECmi8+qsJJ9s7WjUlKG8MkjHSVo/gV6FV88=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=

--- a/vendor/kubestash.dev/apimachinery/apis/config/v1alpha1/ctrlmgrconfig_types.go
+++ b/vendor/kubestash.dev/apimachinery/apis/config/v1alpha1/ctrlmgrconfig_types.go
@@ -149,8 +149,6 @@ type ControllerWebhook struct {
 // +kubebuilder:object:root=true
 
 // ControllerManagerConfiguration is the Schema for the GenericControllerManagerConfigurations API.
-//
-// Deprecated: The component config package has been deprecated and will be removed in a future release. Users should migrate to their own config implementation, please share feedback in https://github.com/kubernetes-sigs/controller-runtime/issues/895.
 type ControllerManagerConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -159,8 +157,6 @@ type ControllerManagerConfiguration struct {
 }
 
 // Complete returns the configuration for controller-runtime.
-//
-// Deprecated: The component config package has been deprecated and will be removed in a future release. Users should migrate to their own config implementation, please share feedback in https://github.com/kubernetes-sigs/controller-runtime/issues/895.
 func (c *ControllerManagerConfigurationSpec) Complete() (ControllerManagerConfigurationSpec, error) {
 	return *c, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -835,7 +835,7 @@ kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.29.0
 ## explicit; go 1.21.5
 kmodules.xyz/prober/api/v1
-# kubestash.dev/apimachinery v0.8.1-0.20240604180741-126c359043bc
+# kubestash.dev/apimachinery v0.9.0
 ## explicit; go 1.22.0
 kubestash.dev/apimachinery/apis
 kubestash.dev/apimachinery/apis/addons/v1alpha1


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2024.6.4
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/14
Signed-off-by: 1gtm <1gtm@appscode.com>