### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/pkg/unlock.go
+++ b/pkg/unlock.go
@@ -217,16 +217,18 @@ func (opt *unlockOptions) runCmdViaDocker(args []string) error {
 		return err
 	}
 
-	unlockArgs := []string{
+	unlockArgs := make([]string, 0, 13+len(args))
+	unlockArgs = append(
+		unlockArgs,
 		"run",
 		"--rm",
 		"-u", currentUser.Uid,
-		"-v", ScratchDir + ":" + ScratchDir,
-		"--env", fmt.Sprintf("%s=", EnvHttpProxy) + os.Getenv(EnvHttpProxy),
-		"--env", fmt.Sprintf("%s=", EnvHttpsProxy) + os.Getenv(EnvHttpsProxy),
+		"-v", ScratchDir+":"+ScratchDir,
+		"--env", fmt.Sprintf("%s=", EnvHttpProxy)+os.Getenv(EnvHttpProxy),
+		"--env", fmt.Sprintf("%s=", EnvHttpsProxy)+os.Getenv(EnvHttpsProxy),
 		"--env-file", filepath.Join(ConfigDir, ResticEnvs),
 		imgRestic.Image,
-	}
+	)
 
 	unlockArgs = append(unlockArgs, args...)
 	klog.Infoln("Running docker with args:", unlockArgs)

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -248,7 +248,8 @@ func showLogs(pod core.Pod, args ...string) error {
 	if err != nil {
 		return err
 	}
-	cmdArgs := []string{"logs", "-n", pod.Namespace, pod.Name}
+	cmdArgs := make([]string, 0, 4+len(args))
+	cmdArgs = append(cmdArgs, "logs", "-n", pod.Namespace, pod.Name)
 	cmdArgs = append(cmdArgs, args...)
 	return sh.Command(CmdKubectl, cmdArgs).Run()
 }


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.

### Resulting fixes
- Preallocate slices flagged by the newly-enabled `prealloc` linter (capacity hints from the ranges being appended). No behavioral change.
